### PR TITLE
Fix for nil cheat_sheets

### DIFF
--- a/.hammerspoon/modules/cheatsheet.lua
+++ b/.hammerspoon/modules/cheatsheet.lua
@@ -388,9 +388,11 @@ end
 function m.stop()
   if chooser then chooser:delete() end
   hideCheatsheet()
-  for name,_ in pairs(cheat_sheets) do
-    cheat_sheets[name] = nil
-    last_changed[name] = nil
+  if (cheat_sheets and type(cheat_sheets) == "table") then
+    for name,_ in pairs(cheat_sheets) do
+      cheat_sheets[name] = nil
+      last_changed[name] = nil
+    end
   end
   cheat_sheets = nil
   last_changed = nil


### PR DESCRIPTION
This fixes an error I was seeing occasionally if cheat_sheets is empty. I think it was happening if my reload function was called while the modules were stopped.

```
18:09:29 ERROR:   LuaSkin: hs.pathwatcher callback error: /Users/richd140/.hammerspoon/modules/cheatsheet.lua:392: bad argument #1 to 'pairs' (table expected, got nil)
stack traceback:
    [C]: in function 'pairs'
    /Users/richd140/.hammerspoon/modules/cheatsheet.lua:392: in function 'modules.cheatsheet.stop'
    /Users/richd140/.hammerspoon/misc_functions.lua:102: in function 'stopModule'
    ...on.app/Contents/Resources/extensions/hs/fnutils/init.lua:87: in function 'hs.fnutils.each'
    /Users/richd140/.hammerspoon/misc_functions.lua:7: in function 'reloadConfig'
```
